### PR TITLE
ci(dependabot): update to group dependabot PRs and limit only to secu…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,31 +2,49 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: pip
     versioning-strategy: increase-if-necessary
-    directory: "/"
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "sunday"
-    commit-message:
-      prefix: "ci(dependabot-pip): "
-    reviewers: ["espressif/ci"]
+      interval: weekly
+      day: sunday
+    open-pull-requests-limit: 0 # Only security updates
+    groups:
+      pip-security-updates:
+        applies-to: security-updates
+        patterns: ['*']
+        update-types: [major, minor, patch]
+    commit-message: {prefix: 'ci(deps-pip): [skip ci]'}
+    reviewers: ['espressif/ci']
+    labels: ['dependencies', 'Status: Reviewing']
 
-  - package-ecosystem: "npm"
+  - package-ecosystem: npm
     versioning-strategy: increase-if-necessary
-    directory: "/"
+    open-pull-requests-limit: 0 # Only security updates
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "sunday"
-    commit-message:
-      prefix: "ci(dependabot-npm): "
-    reviewers: ["espressif/ci"]
+      interval: weekly
+      day: sunday
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns: ['*']
+        update-types: [major, minor, patch]
+    commit-message: {prefix: 'ci(deps-npm): [skip ci]'}
+    reviewers: ['espressif/ci']
+    labels: ['dependencies', 'Status: Reviewing']
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    open-pull-requests-limit: 0 # Only security updates
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "sunday"
-    commit-message:
-      prefix: "ci(dependabot-actions): "
-    reviewers: ["espressif/ci"]
+      interval: weekly
+      day: sunday
+    groups:
+      github-actions-security-updates:
+        applies-to: security-updates
+        patterns: ['*']
+        update-types: [major, minor, patch]
+    commit-message: {prefix: 'ci(deps-npm): [skip ci]'}
+    reviewers: ['espressif/ci']
+    labels: ['dependencies', 'Status: Reviewing']


### PR DESCRIPTION
## Description

This changes the Dependabot settings to:
- Create a PR only for security updates.
- Group all dependency updates into a single PR.
- Set the commit message to follow the conventional and Espressif standard format: `ci(deps-xxx): [skip ci] <message-subject>`.
- Add the `[skip ci]` marker to the commit message to skip CI (pre-commit / danger can fail).

## Links to GitHub Dependabot docs:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
