### PR TITLE
fix(inputs): add fallback to ENV for inputs JIRA_COMPONENT and JIRA_TASK

### DIFF
--- a/.github/workflows/sync-jira.yml
+++ b/.github/workflows/sync-jira.yml
@@ -48,4 +48,4 @@ jobs:
           JIRA_URL: ${{ secrets.JIRA_URL }}
           JIRA_USER: ${{ secrets.JIRA_USER }}
           JIRA_PROJECT: RDT
-          JIRA_COMPONENT: 'github-actions-development'
+          JIRA_COMPONENT: 'github-actions-development' # pragma: allowlist secret

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,6 @@ runs:
         JIRA_URL: ${{ env.JIRA_URL }} # Needs to be passed from caller workflow; by ENV (secure), not by input
         JIRA_USER: ${{ env.JIRA_USER }} # Needs to be passed from caller workflow; by ENV (secure), not by input
         INPUT_CRON_JOB: ${{ github.event_name == 'schedule' && 'true' || '' }}
-        JIRA_PROJECT: ${{ inputs.jira-project != '' && inputs.jira-project || env.JIRA_PROJECT }} # Try input, fallback to enn
-        JIRA_COMPONENT: ${{ inputs.jira-component }}
-        JIRA_ISSUE_TYPE: ${{ inputs.jira-issue-type }}
+        JIRA_PROJECT: ${{ inputs.jira-project != '' && inputs.jira-project || env.JIRA_PROJECT }} # Try input, fallback to env
+        JIRA_COMPONENT: ${{ inputs.jira-component || env.JIRA_COMPONENT }} # Try input, fallback to env
+        JIRA_ISSUE_TYPE: ${{ inputs.jira-issue-type || env.JIRA_COMPONENT }}  # Try input, fallback to env


### PR DESCRIPTION
## Description

The Jira component defined in the target project workflow doesn't take effect (sync runs, but ticket created with empty component). 

In our target projects, workflows are mostly set as `ENV`, but the action file (`action.yml`) is missing a fallback option for reading the value of `JIRA_COMPONENT` from `ENV` (same for `JIRA_ISSUE_TYPE`).

This is a quick patch. The entire GitHub Action is planned for a complete refactor very soon.

## Related
- Internal ticket RDT-930 (all code of this repo refactor)
- Reported in [espressif/esp-video-components#12](https://github.com/espressif/esp-video-components/issues/12) by @wujiangang