### PR TITLE
fix: JIRA component env var ignored due to input default value (SRV-99)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,12 +19,10 @@ inputs:
       If this is not passed one way or another, a check in the sync script will cause the action to fail.
 
   jira-component:
-    description: 'The JIRA component to which the issues will be assigned. Default = "GitHub"'
-    default: 'GitHub'
+    description: 'The JIRA component to which the issues will be assigned. Default = "GitHub". Can also be set with the JIRA_COMPONENT environment variable.'
 
   jira-issue-type:
-    description: 'The type of JIRA issue to be created if no labels to the issue are set. Default = "Task"'
-    default: 'Task'
+    description: 'The type of JIRA issue to be created if no labels to the issue are set. Default = "Task". Can also be set with the JIRA_ISSUE_TYPE environment variable.'
 
   action: # Required only for 'workflow_dispatch' trigger, handled by code logic
     description: 'Manual action type'
@@ -77,5 +75,5 @@ runs:
         WEBHOOK_URL: ${{ env.WEBHOOK_URL }} # Needs to be passed from caller workflow; by ENV (secure), not by input. URL to send request to with the results of execution
         INPUT_CRON_JOB: ${{ github.event_name == 'schedule' && 'true' || '' }}
         JIRA_PROJECT: ${{ inputs.jira-project != '' && inputs.jira-project || env.JIRA_PROJECT }} # Try input, fallback to env
-        JIRA_COMPONENT: ${{ inputs.jira-component || env.JIRA_COMPONENT }} # Try input, fallback to env
-        JIRA_ISSUE_TYPE: ${{ inputs.jira-issue-type || env.JIRA_COMPONENT }} # Try input, fallback to env
+        JIRA_COMPONENT: ${{ inputs.jira-component || env.JIRA_COMPONENT || 'GitHub' }} # Try input, fallback to env, then default
+        JIRA_ISSUE_TYPE: ${{ inputs.jira-issue-type || env.JIRA_ISSUE_TYPE || 'Task' }} # Try input, fallback to env, then default

--- a/sync_jira_actions/sync_issue.py
+++ b/sync_jira_actions/sync_issue.py
@@ -392,30 +392,30 @@ def _update_components_field(jira, fields, existing_issue=None):
     Check the component exists in the issue's JIRA project before adding it, to prevent
     fatal errors (especially likely if the JIRA issue has been moved between projects) .
     """
-    component = os.environ.get('JIRA_COMPONENT', '')
-    if not component:
+    target_component = os.environ.get('JIRA_COMPONENT', '')
+    if not target_component:
         print('No JIRA_COMPONENT variable set, not updating components field')
         return
 
     if existing_issue:
         # may be a different project if the issue was moved
-        project = jira.project(existing_issue.fields.project.key)
+        project_key = jira.project(existing_issue.fields.project.key)
     else:
-        project = jira.project(os.environ['JIRA_PROJECT'])
-    project_components = jira.project_components(project)
+        project_key = jira.project(os.environ['JIRA_PROJECT'])
+    project_components = jira.project_components(project_key)
 
-    if component not in [c.name for c in project_components]:
+    if target_component not in [c.name for c in project_components]:
         print("JIRA project doesn't contain the configured component, not updating components field")
         return
 
     print('Setting components field')
 
-    fields['components'] = [{'name': component}]
+    fields['components'] = [{'name': target_component}]
     # keep any existing components as well
     if existing_issue:
-        for component in existing_issue.fields.components:
-            if component.name != component:
-                fields['components'].append({'name': component.name})
+        for existing_component in existing_issue.fields.components:
+            if existing_component.name != target_component:
+                fields['components'].append({'name': existing_component.name})
 
 
 def _get_jira_issue_type(jira, gh_issue):


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
- Remove default values from jira-component and jira-issue-type inputs
- Add defaults as final fallback in the expression chain
- Fix typo: JIRA_ISSUE_TYPE was falling back to env.JIRA_COMPONENT
- Fix variable shadowing bug in _update_components_field()

Fixes the issue where JIRA_COMPONENT env var was ignored because the input default 'GitHub' always took precedence.
<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->
Fixes #102
## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
