### PR TITLE
fix: Skip syncing PRs from collaborators and organization members

### DIFF
--- a/sync_jira_actions/sync_pr.py
+++ b/sync_jira_actions/sync_pr.py
@@ -21,6 +21,20 @@ from sync_issue import _create_jira_issue
 from sync_issue import _find_jira_issue
 
 
+def _is_collaborator_or_org_member(github, repo, username):
+    """
+    Check if user is a collaborator or organization member.
+    Returns the user type string if the user has direct access to the repo, None otherwise.
+    """
+    if repo.has_in_collaborators(username):
+        return 'collaborator'
+    if repo.owner.type == 'Organization':
+        org = github.get_organization(repo.owner.login)
+        if org.has_in_members(github.get_user(username)):
+            return 'organization member'
+    return None
+
+
 def sync_remain_prs(jira, issue_callback=None):
     """
     Sync remain PRs (i.e. PRs without any comments) to Jira
@@ -29,22 +43,25 @@ def sync_remain_prs(jira, issue_callback=None):
     repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
     prs = repo.get_pulls(state='open', sort='created', direction='desc')
     for pr in prs:
-        if not repo.has_in_collaborators(pr.user.login):
-            # mock a github issue using current PR
-            gh_issue = {
-                'pull_request': True,
-                'labels': [{'name': lbl.name} for lbl in pr.labels],
-                'number': pr.number,
-                'title': pr.title,
-                'html_url': pr.html_url,
-                'user': {'login': pr.user.login},
-                'state': pr.state,
-                'body': pr.body,
-            }
-            issue = _find_jira_issue(jira, gh_issue)
-            if issue is None:
-                _create_jira_issue(jira, gh_issue)
-                print(f'✔️ Successfully synchronized PR #{pr.number}')
+        user_type = _is_collaborator_or_org_member(github, repo, pr.user.login)
+        if user_type:
+            print(f'⏭️ Skipping PR #{pr.number} - author @{pr.user.login} is a {user_type}')
+            continue
+        # mock a github issue using current PR
+        gh_issue = {
+            'pull_request': True,
+            'labels': [{'name': lbl.name} for lbl in pr.labels],
+            'number': pr.number,
+            'title': pr.title,
+            'html_url': pr.html_url,
+            'user': {'login': pr.user.login},
+            'state': pr.state,
+            'body': pr.body,
+        }
+        issue = _find_jira_issue(jira, gh_issue)
+        if issue is None:
+            _create_jira_issue(jira, gh_issue)
+            print(f'✔️ Successfully synchronized PR #{pr.number}')
 
-            if issue_callback:
-                issue_callback(github_issue=gh_issue, jira_issue=issue)
+        if issue_callback:
+            issue_callback(github_issue=gh_issue, jira_issue=issue)

--- a/sync_jira_actions/sync_to_jira.py
+++ b/sync_jira_actions/sync_to_jira.py
@@ -124,14 +124,22 @@ def main():  # noqa
         if 'pull_request' not in event['issue']:
             event['issue']['pull_request'] = True  # we don't care about the value
 
-    # don't sync if user is our collaborator
+    # don't sync if user is collaborator or organization member
     github = Github(os.environ['GITHUB_TOKEN'])
     repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
     gh_issue = event['issue']
     is_pr = 'pull_request' in gh_issue
-    if is_pr and repo.has_in_collaborators(gh_issue['user']['login']):
-        print('Skipping issue sync for Pull Request from collaborator')
-        return
+    if is_pr:
+        user_type = None
+        if repo.has_in_collaborators(gh_issue['user']['login']):
+            user_type = 'collaborator'
+        elif repo.owner.type == 'Organization':
+            org = github.get_organization(repo.owner.login)
+            if org.has_in_members(github.get_user(gh_issue['user']['login'])):
+                user_type = 'organization member'
+        if user_type:
+            print(f'Skipping PR sync - author @{gh_issue["user"]["login"]} is a {user_type}')
+            return
 
     action_handlers = {
         'issues': {

--- a/tests/test_sync_pr.py
+++ b/tests/test_sync_pr.py
@@ -25,7 +25,13 @@ def mock_github():
         mock_pr.state = 'open'
         mock_pr.body = 'Test body'
         mock_repo.get_pulls.return_value = [mock_pr]
+        mock_repo.owner.type = 'Organization'
+        mock_repo.owner.login = 'fake'
         mock_repo.has_in_collaborators.return_value = False
+
+        mock_org = MagicMock()
+        mock_org.has_in_members.return_value = False
+        MockGithub.return_value.get_organization.return_value = mock_org
 
         MockGithub.return_value.get_repo.return_value = mock_repo
         yield mock_repo
@@ -70,3 +76,31 @@ def test_sync_remain_prs(sync_pr_module, mock_sync_issue, mock_github):
     # Example of verifying call arguments (simplified)
     call_args = mock_create_jira_issue.call_args
     assert 'Test PR' in call_args[0][1]['title'], 'PR title does not match expected value'
+
+
+def test_sync_remain_prs_skips_org_members(sync_pr_module, mock_sync_issue, mock_github):
+    """Test that PRs from org members are skipped"""
+    mock_jira = MagicMock()
+    mock_create_jira_issue, mock_find_jira_issue = mock_sync_issue
+
+    # Patch the internal function to return 'organization member'
+    with patch.object(sync_pr_module, '_is_collaborator_or_org_member', return_value='organization member'):
+        sync_pr_module.sync_remain_prs(mock_jira)
+
+    # Verify no JIRA issue was created for org member PR
+    assert mock_create_jira_issue.call_count == 0
+    assert mock_find_jira_issue.call_count == 0
+
+
+def test_sync_remain_prs_skips_collaborators(sync_pr_module, mock_sync_issue, mock_github):
+    """Test that PRs from collaborators are skipped"""
+    mock_jira = MagicMock()
+    mock_create_jira_issue, mock_find_jira_issue = mock_sync_issue
+
+    # Patch the internal function to return 'collaborator'
+    with patch.object(sync_pr_module, '_is_collaborator_or_org_member', return_value='collaborator'):
+        sync_pr_module.sync_remain_prs(mock_jira)
+
+    # Verify no JIRA issue was created for collaborator PR
+    assert mock_create_jira_issue.call_count == 0
+    assert mock_find_jira_issue.call_count == 0


### PR DESCRIPTION
Fixes an issue where PRs from GitHub Team Members and collaborators were still being synced to Jira when they should be ignored.
Root Cause
The previous implementation used repo.has_in_collaborators() which only checks for direct repository collaborators. It did not detect:
- Organization members (public or private)
- Team members with repo access
This caused PRs from internal team members to be incorrectly synced to Jira.
Changes
- Added _is_collaborator_or_org_member() helper function that checks both:
  - Direct collaborators via repo.has_in_collaborators()
  - Organization members via org.has_in_members() (works for both public and private members)
- Updated both sync paths:
  - sync_pr.py - cron job PR sync
  - sync_to_jira.py - event-based PR sync
- Added clear log messages indicating why a PR was skipped:
  - ⏭️ Skipping PR #123 - author @username is a collaborator
  - ⏭️ Skipping PR #123 - author @username is a organization member
- Added tests for both skip scenarios