### PR TITLE
ci(deps): upgrade all pinned dependencies via pip-compile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,56 +4,56 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras pyproject.toml
 #
-certifi==2024.2.2
+certifi==2026.2.25
     # via requests
-cffi==1.16.0
+cffi==2.0.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.6
     # via requests
-cryptography==42.0.4
+cryptography==46.0.6
     # via pyjwt
 defusedxml==0.7.1
     # via jira
-deprecated==1.2.18
+deprecated==1.3.1
     # via pygithub
 idna==3.11
     # via requests
 jira==3.6.0
     # via sync-jira-actions (pyproject.toml)
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via requests-oauthlib
-packaging==23.2
+packaging==26.0
     # via jira
-pillow==10.2.0
+pillow==12.1.1
     # via jira
-pycparser==2.22
+pycparser==3.0
     # via cffi
 pygithub==2.2.0
     # via sync-jira-actions (pyproject.toml)
-pyjwt==2.8.0
+pyjwt==2.12.1
     # via pygithub
-pynacl==1.5.0
+pynacl==1.6.2
     # via pygithub
-requests==2.31.0
+requests==2.33.0
     # via
     #   jira
     #   pygithub
     #   requests-oauthlib
     #   requests-toolbelt
     #   sync-jira-actions (pyproject.toml)
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via jira
 requests-toolbelt==1.0.0
     # via jira
-typing-extensions==4.13.2
+typing-extensions==4.15.0
     # via
     #   jira
     #   pygithub
-urllib3==2.2.0
+urllib3==2.6.3
     # via
     #   pygithub
     #   requests
-wrapt==1.16.0
+wrapt==2.1.2
     # via deprecated


### PR DESCRIPTION
## Summary

Regenerated `requirements.txt` with `pip-compile --upgrade` (Python 3.12) to consolidate all open dependabot PRs into a single update.

Covers dependabot PRs: #108, #109, #110, #111, #114

### Updated dependencies

| Package | From | To |
|---|---|---|
| certifi | 2024.2.2 | 2026.2.25 |
| cffi | 1.16.0 | 2.0.0 |
| charset-normalizer | 3.3.2 | 3.4.6 |
| cryptography | 42.0.4 | 46.0.6 |
| deprecated | 1.2.18 | 1.3.1 |
| oauthlib | 3.2.2 | 3.3.1 |
| packaging | 23.2 | 26.0 |
| pillow | 10.2.0 | 12.1.1 |
| pycparser | 2.22 | 3.0 |
| pyjwt | 2.8.0 | 2.12.1 |
| pynacl | 1.5.0 | 1.6.2 |
| requests | 2.31.0 | 2.33.0 |
| requests-oauthlib | 1.3.1 | 2.0.0 |
| typing-extensions | 4.13.2 | 4.15.0 |
| urllib3 | 2.2.0 | 2.6.3 |
| wrapt | 1.16.0 | 2.1.2 |

### Notable security fixes
- **cryptography 46.0.6**: CVE-2026-26007 (binary elliptic curves key leak)
- **urllib3 2.6.3**: CVE-2026-21441 (decompression bomb bypass on redirects)
- **requests 2.33.0**: CVE-2024-47081 (netrc credential leak)

## Test plan
- [ ] CI passes with updated dependencies
- [ ] Existing tests pass without modifications

Once merged, dependabot PRs #108, #109, #110, #111, #114 can be closed.