### PR TITLE
ci: fix DangerJS workflow permissions

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: write
+      contents: read
     steps:
       - name: Check out PR head
         uses: actions/checkout@v4


### PR DESCRIPTION
Security update: Modifies DangerJS workflow permissions from `contents: write` to `contents: read`.

**Enable workflow `.github/workflows/dangerjs.yml` when this merged - currently disabled!**