### PR TITLE
ci(dependabot-pip): update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@
     urls.Source = "https://github.com/espressif/sync-jira-actions/tags"
     urls.Tracker = "https://github.com/espressif/sync-jira-actions/tags/issues"
 
-    dependencies              = ["PyGithub==2.2.0", "jira==3.6.0", "requests>=2.25.0"]
-    optional-dependencies.dev = ["czespressif", "just-bin~=1.26.0", "pip-tools~=7.3", "pre-commit>=3.3", "pytest", "pytest-cov"]
+    dependencies              = ["PyGithub==2.9.0", "jira==3.6.0", "requests>=2.25.0"]
+    optional-dependencies.dev = ["czespressif", "just-bin~=1.48.1", "pip-tools~=7.3", "pre-commit>=3.3", "pytest", "pytest-cov"]
 
 [build-system]
     build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,14 +10,12 @@ cffi==2.0.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via pyjwt
 defusedxml==0.7.1
     # via jira
-deprecated==1.3.1
-    # via pygithub
 idna==3.11
     # via requests
 jira==3.6.0
@@ -26,11 +24,11 @@ oauthlib==3.3.1
     # via requests-oauthlib
 packaging==26.0
     # via jira
-pillow==12.1.1
+pillow==12.2.0
     # via jira
 pycparser==3.0
     # via cffi
-pygithub==2.2.0
+pygithub==2.9.0
     # via sync-jira-actions (pyproject.toml)
 pyjwt==2.12.1
     # via pygithub
@@ -55,5 +53,3 @@ urllib3==2.6.3
     # via
     #   pygithub
     #   requests
-wrapt==2.1.2
-    # via deprecated


### PR DESCRIPTION
## Summary

Regenerated `requirements.txt` with `pip-compile --upgrade` (Python 3.12) to consolidate all open dependabot PRs into a single update.

Covers dependabot PRs: https://github.com/espressif/sync-jira-actions/pull/125, https://github.com/espressif/sync-jira-actions/pull/124, https://github.com/espressif/sync-jira-actions/pull/123, https://github.com/espressif/sync-jira-actions/pull/122, https://github.com/espressif/sync-jira-actions/pull/120

Once merged, the dependabot PRs above can be closed.