### PR TITLE
fix: Added all event types that the Python code handles (SRV-214)

### DIFF
--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Check out PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/sync-jira.yml
+++ b/.github/workflows/sync-jira.yml
@@ -13,7 +13,7 @@ run-name: >
       github.event_name == 'workflow_dispatch' && 'Manual Sync' }}
 
 on:
-  issues: {types: [opened]}
+  issues: {types: [opened, edited, closed, deleted, reopened, labeled, unlabeled]}
   issue_comment: {types: [created, edited, deleted]}
   schedule: [cron: '0 * * * *']
   workflow_dispatch:

--- a/.github/workflows/sync-jira.yml
+++ b/.github/workflows/sync-jira.yml
@@ -1,15 +1,16 @@
 ---
 # This GitHub Actions workflow synchronizes GitHub issues, comments, and pull requests with Jira.
-# It triggers on new issues, issue comments, and on a scheduled basis.
+# It triggers on issue events (opened, edited, closed, deleted, reopened, labeled, unlabeled),
+# issue comments (created, edited, deleted), and on a scheduled basis.
 # The workflow uses a custom action to perform the synchronization with Jira (espressif/sync-jira-actions).
 
 name: 🔷 Sync to Jira
 
 run-name: >
   Sync to Jira -
-  ${{ github.event_name == 'issue_comment' && 'Issue Comment' ||
+  ${{ github.event_name == 'issue_comment' && format('Issue Comment ({0})', github.event.action) ||
       github.event_name == 'schedule' && 'New Pull Requests' ||
-      github.event_name == 'issues' && 'New Issue' ||
+      github.event_name == 'issues' && format('Issue ({0})', github.event.action) ||
       github.event_name == 'workflow_dispatch' && 'Manual Sync' }}
 
 on:
@@ -25,9 +26,9 @@ jobs:
   sync-to-jira:
     name: >
       Sync to Jira -
-      ${{ github.event_name == 'issue_comment' && 'Issue Comment' ||
+      ${{ github.event_name == 'issue_comment' && format('Issue Comment ({0})', github.event.action) ||
           github.event_name == 'schedule' && 'New Pull Requests' ||
-          github.event_name == 'issues' && 'New Issue' ||
+          github.event_name == 'issues' && format('Issue ({0})', github.event.action) ||
           github.event_name == 'workflow_dispatch' && 'Manual Sync' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/sync-jira.yml
+++ b/.github/workflows/sync-jira.yml
@@ -37,7 +37,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run synchronization to Jira
         uses: espressif/sync-jira-actions@v1

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This action automates the integration of your GitHub repositories with JIRA proj
 - **Custom Field Mapping**: A JIRA custom field named "GitHub Reference" is populated with the URL of the GitHub issue.
 - **Issue Title Sync**: The title of the GitHub issue is updated to include the JIRA issue key.
 - **Bi-directional Comment Sync**: Comments added to a GitHub issue are mirrored in the corresponding JIRA issue. Edits and deletions are also reflected.
-- **Label Synchronization**: Labels added or removed from the GitHub issue are similarly updated in the JIRA issue.
+- **Label Synchronization**: Labels added or removed from a GitHub issue are mirrored in the corresponding JIRA issue (excluding labels prefixed with `Status:` or `Resolution:`, which flow from JIRA back to GitHub).
 - **Remote Issue Link**: After syncing, a [Remote Issue Link](https://developer.atlassian.com/server/jira/platform/creating-remote-issue-links/) is created on the JIRA issue for easy reference back to the GitHub issue.
 
 ## 'Synced From' Link Details
@@ -85,7 +85,7 @@ The GitHub to JIRA Issue Sync Action intelligently creates JIRA issues with spec
 
 There are certain limitations to the data and events that can be synchronized:
 
-- **Labels**: The action does not sync labels between GitHub and JIRA, with the exception of labels that match JIRA issue types. This means that general labels used for categorization or prioritization in GitHub won't automatically reflect in JIRA.
+- **Labels**: Labels that match JIRA issue types determine the issue type at creation time. Changes to such labels after creation do not alter the JIRA issue type (see [Issue Type Synchronization](#issue-type-synchronization)). General labels are synced as JIRA labels via `labeled`/`unlabeled` events, but labels prefixed with `Status:` or `Resolution:` are excluded to avoid feedback loops.
 - **Transitions**: Changes in the status of a GitHub issue, such as closing, reopening, or deleting, do not automatically result in the corresponding transition of the JIRA issue's status. Instead, these actions result in a comment being added to the linked JIRA issue to record the event. This design choice accounts for scenarios where a GitHub issue might be closed by its reporter, but the underlying problem it documents still requires attention and resolution within the JIRA project.
 
 ## Caller project workflow file
@@ -94,20 +94,21 @@ There are certain limitations to the data and events that can be synchronized:
 # FILE: .github/workflows/sync-jira.yml
 ---
 # This GitHub Actions workflow synchronizes GitHub issues, comments, and pull requests with Jira.
-# It triggers on new issues, issue comments, and on a scheduled basis.
+# It triggers on issue events (opened, edited, closed, deleted, reopened, labeled, unlabeled),
+# issue comments (created, edited, deleted), and on a scheduled basis.
 # The workflow uses a custom action to perform the synchronization with Jira (espressif/sync-jira-actions).
 
 name: 🔷 Sync to Jira
 
 run-name: >
   Sync to Jira -
-  ${{ github.event_name == 'issue_comment' && 'Issue Comment' ||
+  ${{ github.event_name == 'issue_comment' && format('Issue Comment ({0})', github.event.action) ||
       github.event_name == 'schedule' && 'New Pull Requests' ||
-      github.event_name == 'issues' && 'New Issue' ||
+      github.event_name == 'issues' && format('Issue ({0})', github.event.action) ||
       github.event_name == 'workflow_dispatch' && 'Manual Sync' }}
 
 on:
-  issues: {types: [opened]}
+  issues: {types: [opened, edited, closed, deleted, reopened, labeled, unlabeled]}
   issue_comment: {types: [created, edited, deleted]}
   schedule: [cron: '0 * * * *']
   workflow_dispatch:
@@ -119,9 +120,9 @@ jobs:
   sync-to-jira:
     name: >
       Sync to Jira -
-      ${{ github.event_name == 'issue_comment' && 'Issue Comment' ||
+      ${{ github.event_name == 'issue_comment' && format('Issue Comment ({0})', github.event.action) ||
           github.event_name == 'schedule' && 'New Pull Requests' ||
-          github.event_name == 'issues' && 'New Issue' ||
+          github.event_name == 'issues' && format('Issue ({0})', github.event.action) ||
           github.event_name == 'workflow_dispatch' && 'Manual Sync' }}
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run synchronization to Jira
         uses: espressif/sync-jira-actions@v1

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: Checkout action repository (espressif/sync-jira-actions)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: espressif/sync-jira-actions
 

--- a/docs/sync-jira.yml
+++ b/docs/sync-jira.yml
@@ -2,20 +2,21 @@
 # FILE: .github/workflows/sync-jira.yml
 
 # This GitHub Actions workflow synchronizes GitHub issues, comments, and pull requests with Jira.
-# It triggers on new issues, issue comments, and on a scheduled basis.
+# It triggers on issue events (opened, edited, closed, deleted, reopened, labeled, unlabeled),
+# issue comments (created, edited, deleted), and on a scheduled basis.
 # The workflow uses a custom action to perform the synchronization with Jira (espressif/sync-jira-actions).
 
 name: 🔷 Sync to Jira
 
 run-name: >
   Sync to Jira -
-  ${{ github.event_name == 'issue_comment' && 'Issue Comment' ||
+  ${{ github.event_name == 'issue_comment' && format('Issue Comment ({0})', github.event.action) ||
       github.event_name == 'schedule' && 'New Pull Requests' ||
-      github.event_name == 'issues' && 'New Issue' ||
+      github.event_name == 'issues' && format('Issue ({0})', github.event.action) ||
       github.event_name == 'workflow_dispatch' && 'Manual Sync' }}
 
 on:
-  issues: {types: [opened]}
+  issues: {types: [opened, edited, closed, deleted, reopened, labeled, unlabeled]}
   issue_comment: {types: [created, edited, deleted]}
   schedule: [cron: '0 * * * *']
   workflow_dispatch:
@@ -27,9 +28,9 @@ jobs:
   sync-to-jira:
     name: >
       Sync to Jira -
-      ${{ github.event_name == 'issue_comment' && 'Issue Comment' ||
+      ${{ github.event_name == 'issue_comment' && format('Issue Comment ({0})', github.event.action) ||
           github.event_name == 'schedule' && 'New Pull Requests' ||
-          github.event_name == 'issues' && 'New Issue' ||
+          github.event_name == 'issues' && format('Issue ({0})', github.event.action) ||
           github.event_name == 'workflow_dispatch' && 'Manual Sync' }}
     runs-on: ubuntu-latest
     permissions:
@@ -38,7 +39,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run synchronization to Jira
         uses: espressif/sync-jira-actions@v1

--- a/sync_jira_actions/sync_issue.py
+++ b/sync_jira_actions/sync_issue.py
@@ -72,12 +72,12 @@ def handle_issue_closed(jira, event):
     # issues often get closed for the wrong reasons - ie the user
     # found a workaround but the root cause still exists.
     issue = _leave_jira_issue_comment(jira, event, 'closed', False)
-    try:
-        # Sets value of custom GitHub Issue field to Closed
-        issue.update(fields={'customfield_12100': {'value': 'Closed'}})
-    except JIRAError as error:
-        print(f'Could not set GitHub Issue field to Closed when closing issue with error: {error}')
     if issue is not None:
+        try:
+            # Sets value of custom GitHub Issue field to Closed
+            issue.update(fields={'customfield_12100': {'value': 'Closed'}})
+        except JIRAError as error:
+            print(f'Could not set GitHub Issue field to Closed when closing issue with error: {error}')
         _update_link_resolved(jira, event['issue'], issue)
 
     return issue

--- a/tests/test_sync_issue.py
+++ b/tests/test_sync_issue.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import pytest
 
-
 @pytest.fixture(autouse=True)
 def setup_env(monkeypatch):
     monkeypatch.setenv('GITHUB_TOKEN', 'fake-token')
@@ -36,7 +35,19 @@ def sync_issue_module(github_client_mock):
     return sync_issue
 
 
-# Example test function
+
+def test_workflow_triggered_on_issue_actions():
+    with open('.github/workflows/sync-jira.yml') as f:
+        content = f.read()
+    assert 'opened' in content
+    assert 'closed' in content
+    assert 'reopened' in content
+    assert 'labeled' in content
+    assert 'unlabeled' in content
+    assert 'deleted' in content
+    assert 'edited' in content
+
+
 def test_handle_issue_opened_creates_jira_issue(sync_issue_module, github_client_mock):
     _, mock_repo = github_client_mock
     mock_jira_client = MagicMock()


### PR DESCRIPTION
## Description

- The issues event is configured to trigger only on `opened`. It completely misses `closed`, `reopened`, `edited`, `labeled`, `unlabeled`, and `deleted` events.

    The workflow was newer triggered on `closed` event. 

    Most probably the closed status was synchronised after being triggered on the `issue_comment` event. If                        someone commented after closing → the workflow ran, the comment synced, but the closed status still never synced. If no one commented → the workflow never ran at all for that issue. 

- Unrelated change: issue.update() was called before the None check, crashing with AttributeError instead of the expected JIRAError. Moved both calls inside the if issue is not None: guard.

## Solution

Add all event types that the Python code handles: `opened`, `edited`, `closed`, `deleted`, `reopened`, `labeled`, `unlabeled`.

The amount of Action run will increase, but the change will not influence the billing since the repo is public.
<img width="628" height="165" alt="Screenshot 2026-04-17 at 11 25 59" src="https://github.com/user-attachments/assets/549b2e16-4463-431d-9cf2-bd6046d3b1d7" />

## Related

Fixes: Github resolution status is not reliably synced to Jira (SRV-66)
## Testing

Please see added tests.
---
