### PR TITLE
fix: use dedicated PAT for org membership check to fix private member… (SRV-215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,21 @@ The GitHub to JIRA Issue Sync workflow requires the configuration of specific en
 
 Below is a detailed table outlining the necessary configurations:
 
-| Variable/Secret   | Description                                                                                  | Requirement |
-| ----------------- | -------------------------------------------------------------------------------------------- | ----------- |
-| `JIRA_PROJECT`    | Specifies the Jira project to synchronize with.                                              | Mandatory   |
-| `JIRA_ISSUE_TYPE` | Specifies the JIRA issue type for new issues. Defaults to "Task" if not set.                 | Optional    |
-| `JIRA_COMPONENT`  | The name of a JIRA component to add to every synced issue. The component must exist in JIRA. | Optional    |
-| `WEBHOOK_URL`     | URL to be called after successful action                                                     | Optional    |
-| `JIRA_URL`        | The main URL of your JIRA instance.                                                          | Inherited   |
-| `JIRA_USER`       | The username used for logging into JIRA (basic auth).                                        | Inherited   |
-| `JIRA_PASS`       | The JIRA token (for token auth) or password (for basic auth) used for logging in.            | Inherited   |
+| Variable/Secret         | Description                                                                                                                                                    | Requirement |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `JIRA_PROJECT`          | Specifies the Jira project to synchronize with.                                                                                                                | Mandatory   |
+| `JIRA_ISSUE_TYPE`       | Specifies the JIRA issue type for new issues. Defaults to "Task" if not set.                                                                                   | Optional    |
+| `JIRA_COMPONENT`        | The name of a JIRA component to add to every synced issue. The component must exist in JIRA.                                                                   | Optional    |
+| `WEBHOOK_URL`           | URL to be called after successful action                                                                                                                       | Optional    |
+| `JIRA_URL`              | The main URL of your JIRA instance.                                                                                                                            | Inherited   |
+| `JIRA_USER`             | The username used for logging into JIRA (basic auth).                                                                                                          | Inherited   |
+| `JIRA_PASS`             | The JIRA token (for token auth) or password (for basic auth) used for logging in.                                                                              | Inherited   |
+| `GITHUB_ORG_READ_TOKEN` | GitHub PAT with `read:org` scope. Required to skip PRs from org members whose membership is **private**. Without it, those PRs are incorrectly synced to Jira. | Inherited   |
 
-- **GitHub Organizational Secrets**: `JIRA_URL`, `JIRA_USER`, `JIRA_PASS` - These secrets are **inherited from the GitHub organizational secrets, as they are common to all projects within the organization**.
+- **GitHub Organizational Secrets**: `JIRA_URL`, `JIRA_USER`, `JIRA_PASS`, `SYNC_JIRA_ORG_READ_TOKEN` - These secrets are **inherited from the GitHub organizational secrets, as they are common to all projects within the organization**.
+
+> \[!NOTE\]
+> `SYNC_JIRA_ORG_READ_TOKEN` is a one-time org-level setup: create a Classic PAT with `read:org` scope on a service account, store it at [github.com/organizations/espressif/settings/secrets/actions](https://github.com/organizations/espressif/settings/secrets/actions) (access: *All repositories*), then add `GITHUB_ORG_READ_TOKEN: ${{ secrets.SYNC_JIRA_ORG_READ_TOKEN }}` to the `env:` block in each repo's `sync-jira.yml`.
 
 > \[!WARNING\]
 > Do not to set secrets at the individual repository level to avoid conflicts and ensure a unified configuration across all projects.

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
         python sync_jira_actions/sync_to_jira.py
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }} # Needs to be passed from caller workflow; by ENV (secure), not by input
+        GITHUB_ORG_READ_TOKEN: ${{ env.GITHUB_ORG_READ_TOKEN }} # Optional PAT with read:org scope; required to detect private org membership (GITHUB_TOKEN lacks this scope)
         JIRA_PASS: ${{ env.JIRA_PASS }} # Needs to be passed from caller workflow; by ENV (secure), not by input
         JIRA_URL: ${{ env.JIRA_URL }} # Needs to be passed from caller workflow; by ENV (secure), not by input
         JIRA_USER: ${{ env.JIRA_USER }} # Needs to be passed from caller workflow; by ENV (secure), not by input

--- a/docs/sync-jira.yml
+++ b/docs/sync-jira.yml
@@ -46,6 +46,9 @@ jobs:
           cron_job: ${{ github.event_name == 'schedule' && 'true' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with read:org scope; stored as an org-level secret in github.com/organizations/espressif/settings/secrets/actions
+          # Required to detect private org membership. Without it, PRs from members with private membership are synced to Jira.
+          GITHUB_ORG_READ_TOKEN: ${{ secrets.SYNC_JIRA_ORG_READ_TOKEN }}
           JIRA_PASS: ${{ secrets.JIRA_PASS }}
           JIRA_PROJECT: IDFSYNTEST   # <---- update for your Jira project
           JIRA_COMPONENT: GitHub

--- a/sync_jira_actions/sync_pr.py
+++ b/sync_jira_actions/sync_pr.py
@@ -15,11 +15,31 @@
 # limitations under the License.
 #
 import os
+import warnings
 
 from github import Github
 from github import GithubException
 from sync_issue import _create_jira_issue
 from sync_issue import _find_jira_issue
+
+
+def _get_org_github_client(github=None):
+    """
+    Return a GitHub client using GITHUB_ORG_READ_TOKEN if set, otherwise GITHUB_TOKEN.
+    GITHUB_ORG_READ_TOKEN should be a PAT with read:org scope so that private org
+    membership can be checked. Falls back to the provided client (or GITHUB_TOKEN)
+    which can only see public org membership.
+    """
+    org_token = os.environ.get('GITHUB_ORG_READ_TOKEN')
+    if org_token:
+        return Github(org_token)
+    warnings.warn(
+        'GITHUB_ORG_READ_TOKEN is not set. Org membership check will only work for '
+        'users with public org membership. Set GITHUB_ORG_READ_TOKEN to a PAT with '
+        'read:org scope to fix this.',
+        stacklevel=2,
+    )
+    return github if github is not None else Github(os.environ['GITHUB_TOKEN'])
 
 
 def _is_collaborator_or_org_member(github, repo, username):
@@ -30,9 +50,10 @@ def _is_collaborator_or_org_member(github, repo, username):
     if repo.has_in_collaborators(username):
         return 'collaborator'
     if repo.owner.type == 'Organization':
-        org = github.get_organization(repo.owner.login)
+        github_org = _get_org_github_client(github)
+        org = github_org.get_organization(repo.owner.login)
         try:
-            if org.has_in_members(github.get_user(username)):
+            if org.has_in_members(github_org.get_user(username)):
                 return 'organization member'
         except GithubException:
             print(f'WARNING ⚠️ Could not check org membership for @{username}, treating as external contributor')

--- a/sync_jira_actions/sync_to_jira.py
+++ b/sync_jira_actions/sync_to_jira.py
@@ -18,7 +18,6 @@ import json
 import os
 
 from github import Github
-from github import GithubException
 from jira import JIRA
 from sync_issue import handle_comment_created
 from sync_issue import handle_comment_deleted
@@ -31,6 +30,7 @@ from sync_issue import handle_issue_opened
 from sync_issue import handle_issue_reopened
 from sync_issue import handle_issue_unlabeled
 from sync_issue import sync_issues_manually
+from sync_pr import _is_collaborator_or_org_member
 from sync_pr import sync_remain_prs
 from webhook import send_webhook
 
@@ -131,19 +131,10 @@ def main():  # noqa
     gh_issue = event['issue']
     is_pr = 'pull_request' in gh_issue
     if is_pr:
-        user_type = None
-        if repo.has_in_collaborators(gh_issue['user']['login']):
-            user_type = 'collaborator'
-        elif repo.owner.type == 'Organization':
-            org = github.get_organization(repo.owner.login)
-            try:
-                if org.has_in_members(github.get_user(gh_issue['user']['login'])):
-                    user_type = 'organization member'
-            except GithubException:
-                username = gh_issue['user']['login']
-                print(f'WARNING ⚠️ Could not check org membership for @{username},' ' treating as external contributor')
+        username = gh_issue['user']['login']
+        user_type = _is_collaborator_or_org_member(github, repo, username)
         if user_type:
-            print(f'Skipping PR sync - author @{gh_issue["user"]["login"]} is a {user_type}')
+            print(f'Skipping PR sync - author @{username} is a {user_type}')
             return
 
     action_handlers = {

--- a/tests/test_sync_pr.py
+++ b/tests/test_sync_pr.py
@@ -106,9 +106,30 @@ def test_sync_remain_prs_skips_collaborators(sync_pr_module, mock_sync_issue, mo
     assert mock_find_jira_issue.call_count == 0
 
 
-def test_is_collaborator_or_org_member_handles_bot_accounts(sync_pr_module):
+def test_is_collaborator_or_org_member_handles_bot_accounts(sync_pr_module, monkeypatch):
     """Test that _is_collaborator_or_org_member returns None for bot accounts"""
     from github import GithubException
+
+    monkeypatch.delenv('GITHUB_ORG_READ_TOKEN', raising=False)
+
+    mock_github_instance = MagicMock()
+    mock_github_instance.get_user.side_effect = GithubException(404, 'Not Found', None)
+    mock_repo = MagicMock()
+    mock_repo.has_in_collaborators.return_value = False
+    mock_repo.owner.type = 'Organization'
+    mock_repo.owner.login = 'fake-org'
+
+    with pytest.warns(UserWarning):
+        result = sync_pr_module._is_collaborator_or_org_member(
+            mock_github_instance, mock_repo, 'copilot[bot]'
+        )
+
+    assert result is None
+
+
+def test_is_collaborator_or_org_member_uses_org_read_token(sync_pr_module, monkeypatch):
+    """Test that _is_collaborator_or_org_member uses GITHUB_ORG_READ_TOKEN when available"""
+    monkeypatch.setenv('GITHUB_ORG_READ_TOKEN', 'org-read-token')
 
     mock_github_instance = MagicMock()
     mock_repo = MagicMock()
@@ -116,11 +137,33 @@ def test_is_collaborator_or_org_member_handles_bot_accounts(sync_pr_module):
     mock_repo.owner.type = 'Organization'
     mock_repo.owner.login = 'fake-org'
 
-    mock_github_instance.get_user.side_effect = GithubException(404, 'Not Found', None)
+    with patch('sync_pr.Github') as MockGithub:
+        mock_org_github = MagicMock()
+        mock_org = MagicMock()
+        mock_org.has_in_members.return_value = True
+        mock_org_github.get_organization.return_value = mock_org
+        MockGithub.return_value = mock_org_github
 
-    result = sync_pr_module._is_collaborator_or_org_member(mock_github_instance, mock_repo, 'copilot[bot]')
+        result = sync_pr_module._is_collaborator_or_org_member(mock_github_instance, mock_repo, 'avgustina')
 
-    assert result is None
+        MockGithub.assert_called_once_with('org-read-token')
+
+    assert result == 'organization member'
+
+
+def test_is_collaborator_or_org_member_warns_without_org_read_token(sync_pr_module, monkeypatch):
+    """Test that a warning is emitted when GITHUB_ORG_READ_TOKEN is not set"""
+    monkeypatch.delenv('GITHUB_ORG_READ_TOKEN', raising=False)
+
+    mock_github_instance = MagicMock()
+    mock_github_instance.get_organization.return_value.has_in_members.return_value = False
+    mock_repo = MagicMock()
+    mock_repo.has_in_collaborators.return_value = False
+    mock_repo.owner.type = 'Organization'
+    mock_repo.owner.login = 'fake-org'
+
+    with pytest.warns(UserWarning, match='GITHUB_ORG_READ_TOKEN'):
+        sync_pr_module._is_collaborator_or_org_member(mock_github_instance, mock_repo, 'testuser')
 
 
 def test_sync_remain_prs_handles_bot_accounts(sync_pr_module, mock_sync_issue, mock_github):


### PR DESCRIPTION
## Explanation of the bug cause - Why a Jira ticket gets created for the user despite him being an org member

### Step by step:

1. A cron job runs every hour, iterates over open PRs, and decides whether to create a Jira ticket.

2. For each PR, org.has_in_members(user) is called — a PyGithub wrapper around the GitHub API endpoint GET /orgs/espressif/members/user.

3. That endpoint behaves as follows:
- If the token belongs to an org member → returns 204 (yes, is a member) or 404 (no).
- If the token is NOT an org member → returns 302 and redirects to the public members endpoint: GET /orgs/espressif/public_members/igor.

4. secrets.GITHUB_TOKEN is the automatic GitHub Actions token. It is not considered an org member from the API's perspective, so it always gets a 302.

5. After the redirect, a request goes to /public_members/igor. If Igor has hidden his org membership (membership set to private in his GitHub settings) — that endpoint returns 404.

6. PyGithub sees 404, has_in_members() returns False. No exception. No warning.

7. The code concludes: Igor is an external contributor → creates ticket CII-127 in Jira.

## Description

Action's `GITHUB_TOKEN` lacks `read:org` scope, so `has_in_members()` silently returns
False for org members with private membership, causing their PRs to be
synced to Jira. 

## Fix

Use dedicated PAT for org membership check (only) to fix private member detection.

## Tests

Add tests covering token selection, warning when token is absent, and bot-account handling

## Related

Fixes SRV-149: Skip syncing PRs from collaborators and organization member Not Working

