### PR TITLE
feat: Ignore PRs with Certain Patterns (SRV-216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This action automates the integration of your GitHub repositories with JIRA proj
 - [Issue Type Synchronization](#issue-type-synchronization)
   - [How It Works](#how-it-works)
 - [Limitations](#limitations)
+- [Ignoring Pull Requests by Pattern](#ignoring-pull-requests-by-pattern)
 - [Caller project workflow file](#caller-project-workflow-file)
 - [Sync Issues and Pull Requests to JIRA manually](#sync-issues-and-pull-requests-to-jira-manually)
 - [Environment Variables and Secrets](#environment-variables-and-secrets)
@@ -87,6 +88,36 @@ There are certain limitations to the data and events that can be synchronized:
 
 - **Labels**: The action does not sync labels between GitHub and JIRA, with the exception of labels that match JIRA issue types. This means that general labels used for categorization or prioritization in GitHub won't automatically reflect in JIRA.
 - **Transitions**: Changes in the status of a GitHub issue, such as closing, reopening, or deleting, do not automatically result in the corresponding transition of the JIRA issue's status. Instead, these actions result in a comment being added to the linked JIRA issue to record the event. This design choice accounts for scenarios where a GitHub issue might be closed by its reporter, but the underlying problem it documents still requires attention and resolution within the JIRA project.
+
+## Ignoring Pull Requests by Pattern
+
+Some pull requests, such as automated dependency bumps or pre-commit auto-updates, are not useful to mirror into JIRA. The action skips these by default and lets you add more via two inputs.
+
+**Built-in defaults (always applied, case-insensitive):**
+
+- Title prefixes: `build(deps):`, `build(deps-dev):`, `[pre-commit.ci]`
+- Author logins: `dependabot[bot]`, `pre-commit-ci[bot]`
+
+**Extending the defaults** — pass additional comma-separated values via action inputs. Your values are **appended** to the defaults (they do not replace them):
+
+| Input                   | Description                                                                                               |
+| ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| `ignore-title-prefixes` | Comma-separated title prefixes (case-insensitive). A PR is ignored if its title starts with any of these. |
+| `ignore-authors`        | Comma-separated author logins (case-insensitive, exact match).                                            |
+
+**Example:**
+
+```yaml
+- name: Run synchronization to Jira
+  uses: espressif/sync-jira-actions@v1
+  with:
+    ignore-title-prefixes: 'chore(deps):, [my-bot]'
+    ignore-authors: 'renovate[bot], myorg-bot[bot]'
+  env:
+    # ... same env as before
+```
+
+The ignore check runs on both the event-driven PR sync and the hourly cron sweep.
 
 ## Caller project workflow file
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,18 @@ inputs:
   issue-numbers: # Required only for 'workflow_dispatch' trigger, handled by code logic
     description: 'Issue numbers to sync (comma-separated)'
 
+  ignore-title-prefixes:
+    description: >
+      Comma-separated list of PR title prefixes to ignore (case-insensitive).
+      Appended to the built-in defaults: "build(deps):", "build(deps-dev):", "[pre-commit.ci]".
+      Example: "chore(deps):, [my-bot]"
+
+  ignore-authors:
+    description: >
+      Comma-separated list of PR author logins to ignore (case-insensitive, exact match).
+      Appended to the built-in defaults: "dependabot[bot]", "pre-commit-ci[bot]".
+      Example: "myorg-bot[bot], renovate[bot]"
+
 runs:
   using: composite
   steps:
@@ -77,3 +89,5 @@ runs:
         JIRA_PROJECT: ${{ inputs.jira-project != '' && inputs.jira-project || env.JIRA_PROJECT }} # Try input, fallback to env
         JIRA_COMPONENT: ${{ inputs.jira-component || env.JIRA_COMPONENT || 'GitHub' }} # Try input, fallback to env, then default
         JIRA_ISSUE_TYPE: ${{ inputs.jira-issue-type || env.JIRA_ISSUE_TYPE || 'Task' }} # Try input, fallback to env, then default
+        INPUT_IGNORE_TITLE_PREFIXES: ${{ inputs.ignore-title-prefixes }} # Comma-separated, appended to defaults
+        INPUT_IGNORE_AUTHORS: ${{ inputs.ignore-authors }} # Comma-separated, appended to defaults

--- a/sync_jira_actions/ignore_pr.py
+++ b/sync_jira_actions/ignore_pr.py
@@ -1,0 +1,91 @@
+# Copyright 2019-2026 Espressif Systems (Shanghai) CO LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Decide whether a PR should be ignored for JIRA syncing based on title prefix or author login.
+
+Defaults are always applied; callers can extend them via the
+``INPUT_IGNORE_TITLE_PREFIXES`` and ``INPUT_IGNORE_AUTHORS`` environment
+variables (comma-separated, case-insensitive).
+"""
+
+import os
+
+DEFAULT_IGNORE_TITLE_PREFIXES = (
+    'build(deps):',
+    'build(deps-dev):',
+    '[pre-commit.ci]',
+)
+
+DEFAULT_IGNORE_AUTHORS = (
+    'dependabot[bot]',
+    'pre-commit-ci[bot]',
+)
+
+
+def _parse_csv_env(var_name: str) -> list[str]:
+    raw = os.environ.get(var_name, '')
+    if not raw:
+        return []
+    return [entry.strip() for entry in raw.split(',') if entry.strip()]
+
+
+def get_ignore_title_prefixes() -> list[str]:
+    """Return the effective list of title prefixes, lowercased, defaults first."""
+    extras = _parse_csv_env('INPUT_IGNORE_TITLE_PREFIXES')
+    combined = list(DEFAULT_IGNORE_TITLE_PREFIXES) + extras
+    # Lowercase for case-insensitive comparison, preserve order, drop duplicates.
+    seen: set[str] = set()
+    result: list[str] = []
+    for prefix in combined:
+        low = prefix.lower()
+        if low not in seen:
+            seen.add(low)
+            result.append(low)
+    return result
+
+
+def get_ignore_authors() -> list[str]:
+    """Return the effective list of author logins, lowercased, defaults first."""
+    extras = _parse_csv_env('INPUT_IGNORE_AUTHORS')
+    combined = list(DEFAULT_IGNORE_AUTHORS) + extras
+    seen: set[str] = set()
+    result: list[str] = []
+    for author in combined:
+        low = author.lower()
+        if low not in seen:
+            seen.add(low)
+            result.append(low)
+    return result
+
+
+def should_ignore_pr(title: str | None, author_login: str | None) -> tuple[bool, str | None]:
+    """Check whether a PR should be ignored.
+
+    Returns ``(True, reason)`` describing which rule matched, or ``(False, None)``.
+    Author match takes precedence over title match because bot authorship is the
+    more reliable signal (the same human can easily use any title).
+    """
+    if author_login:
+        author_low = author_login.lower()
+        for ignored in get_ignore_authors():
+            if author_low == ignored:
+                return True, f"author '{author_login}' matches ignored authors list"
+
+    if title:
+        title_low = title.lower()
+        for prefix in get_ignore_title_prefixes():
+            if title_low.startswith(prefix):
+                return True, f"title starts with ignored prefix '{prefix}'"
+
+    return False, None

--- a/sync_jira_actions/sync_pr.py
+++ b/sync_jira_actions/sync_pr.py
@@ -18,6 +18,7 @@ import os
 
 from github import Github
 from github import GithubException
+from ignore_pr import should_ignore_pr
 from sync_issue import _create_jira_issue
 from sync_issue import _find_jira_issue
 
@@ -50,6 +51,10 @@ def sync_remain_prs(jira, issue_callback=None):
         user_type = _is_collaborator_or_org_member(github, repo, pr.user.login)
         if user_type:
             print(f'⏭️ Skipping PR #{pr.number} - author @{pr.user.login} is a {user_type}')
+            continue
+        ignore, reason = should_ignore_pr(pr.title, pr.user.login)
+        if ignore:
+            print(f'⏭️ Skipping PR #{pr.number} - {reason}')
             continue
         # mock a github issue using current PR
         gh_issue = {

--- a/sync_jira_actions/sync_to_jira.py
+++ b/sync_jira_actions/sync_to_jira.py
@@ -19,6 +19,7 @@ import os
 
 from github import Github
 from github import GithubException
+from ignore_pr import should_ignore_pr
 from jira import JIRA
 from sync_issue import handle_comment_created
 from sync_issue import handle_comment_deleted
@@ -144,6 +145,10 @@ def main():  # noqa
                 print(f'WARNING ⚠️ Could not check org membership for @{username},' ' treating as external contributor')
         if user_type:
             print(f'Skipping PR sync - author @{gh_issue["user"]["login"]} is a {user_type}')
+            return
+        ignore, reason = should_ignore_pr(gh_issue.get('title'), gh_issue['user']['login'])
+        if ignore:
+            print(f'⏭️ Skipping PR #{gh_issue.get("number")} sync - {reason}')
             return
 
     action_handlers = {

--- a/tests/test_ignore_pr.py
+++ b/tests/test_ignore_pr.py
@@ -1,0 +1,178 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def ignore_pr_module(monkeypatch):
+    """Reload the module for each test so env var reads are re-evaluated."""
+    sys.path.insert(0, 'sync_jira_actions')
+    import ignore_pr
+
+    importlib.reload(ignore_pr)
+    return ignore_pr
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv('INPUT_IGNORE_TITLE_PREFIXES', raising=False)
+    monkeypatch.delenv('INPUT_IGNORE_AUTHORS', raising=False)
+
+
+class TestDefaults:
+    def test_default_title_prefix_build_deps(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr(
+            'build(deps): bump actions/download-artifact from 6 to 7', 'somebody'
+        )
+        assert ignore is True
+        assert 'title' in reason.lower()
+
+    def test_default_title_prefix_build_deps_dev(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr('build(deps-dev): bump pytest from 8 to 9', 'somebody')
+        assert ignore is True
+        assert 'title' in reason.lower()
+
+    def test_default_title_prefix_pre_commit_ci(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr('[pre-commit.ci] pre-commit autoupdate', 'somebody')
+        assert ignore is True
+        assert 'title' in reason.lower()
+
+    def test_default_title_prefix_is_case_insensitive(self, ignore_pr_module):
+        ignore, _ = ignore_pr_module.should_ignore_pr('BUILD(DEPS): bump x', 'somebody')
+        assert ignore is True
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('[Pre-Commit.CI] pre-commit autoupdate', 'somebody')
+        assert ignore is True
+
+    def test_default_author_dependabot(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr('Some normal title', 'dependabot[bot]')
+        assert ignore is True
+        assert 'author' in reason.lower()
+
+    def test_default_author_pre_commit_ci(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr('Some normal title', 'pre-commit-ci[bot]')
+        assert ignore is True
+        assert 'author' in reason.lower()
+
+    def test_default_author_is_case_insensitive(self, ignore_pr_module):
+        ignore, _ = ignore_pr_module.should_ignore_pr('Some normal title', 'Dependabot[Bot]')
+        assert ignore is True
+
+
+class TestNotIgnored:
+    def test_regular_pr_is_not_ignored(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr('Fix memory leak in WiFi driver', 'alice')
+        assert ignore is False
+        assert reason is None
+
+    def test_title_containing_but_not_starting_with_prefix(self, ignore_pr_module):
+        """Prefix match only: 'build(deps):' in the middle should not match."""
+        ignore, _ = ignore_pr_module.should_ignore_pr('Refactor build(deps): handling', 'alice')
+        assert ignore is False
+
+
+class TestExtendingDefaults:
+    def test_custom_title_prefix_extends_defaults(self, ignore_pr_module, monkeypatch):
+        monkeypatch.setenv('INPUT_IGNORE_TITLE_PREFIXES', 'chore(deps):, [custom]')
+        importlib.reload(ignore_pr_module)
+
+        ignore, reason = ignore_pr_module.should_ignore_pr('chore(deps): bump thing', 'alice')
+        assert ignore is True
+        assert 'title' in reason.lower()
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('[custom] some pr', 'alice')
+        assert ignore is True
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('build(deps): bump x', 'alice')
+        assert ignore is True
+
+    def test_custom_authors_extends_defaults(self, ignore_pr_module, monkeypatch):
+        monkeypatch.setenv('INPUT_IGNORE_AUTHORS', 'myorg-bot[bot]')
+        importlib.reload(ignore_pr_module)
+
+        ignore, reason = ignore_pr_module.should_ignore_pr('Some PR', 'myorg-bot[bot]')
+        assert ignore is True
+        assert 'author' in reason.lower()
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('Some PR', 'dependabot[bot]')
+        assert ignore is True
+
+    def test_empty_env_var_keeps_defaults(self, ignore_pr_module, monkeypatch):
+        monkeypatch.setenv('INPUT_IGNORE_TITLE_PREFIXES', '')
+        monkeypatch.setenv('INPUT_IGNORE_AUTHORS', '')
+        importlib.reload(ignore_pr_module)
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('build(deps): bump x', 'alice')
+        assert ignore is True
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('Some PR', 'dependabot[bot]')
+        assert ignore is True
+
+    def test_whitespace_and_blank_entries_tolerated(self, ignore_pr_module, monkeypatch):
+        monkeypatch.setenv('INPUT_IGNORE_TITLE_PREFIXES', '  chore(deps): ,  , [custom]  ,')
+        monkeypatch.setenv('INPUT_IGNORE_AUTHORS', ' , my-bot[bot] , ,  ')
+        importlib.reload(ignore_pr_module)
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('chore(deps): bump', 'alice')
+        assert ignore is True
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('[custom] foo', 'alice')
+        assert ignore is True
+
+        ignore, _ = ignore_pr_module.should_ignore_pr('Some PR', 'my-bot[bot]')
+        assert ignore is True
+
+
+class TestNoneInputs:
+    def test_none_title_is_handled(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr(None, 'alice')
+        assert ignore is False
+        assert reason is None
+
+    def test_none_author_is_handled(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr('Fix bug', None)
+        assert ignore is False
+        assert reason is None
+
+    def test_both_none(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr(None, None)
+        assert ignore is False
+        assert reason is None
+
+    def test_none_title_with_ignored_author(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr(None, 'dependabot[bot]')
+        assert ignore is True
+        assert 'author' in reason.lower()
+
+    def test_none_author_with_ignored_title(self, ignore_pr_module):
+        ignore, reason = ignore_pr_module.should_ignore_pr('build(deps): bump x', None)
+        assert ignore is True
+        assert 'title' in reason.lower()
+
+
+class TestGetters:
+    def test_get_ignore_title_prefixes_returns_defaults(self, ignore_pr_module):
+        prefixes = ignore_pr_module.get_ignore_title_prefixes()
+        assert 'build(deps):' in prefixes
+        assert 'build(deps-dev):' in prefixes
+        assert '[pre-commit.ci]' in prefixes
+
+    def test_get_ignore_authors_returns_defaults(self, ignore_pr_module):
+        authors = ignore_pr_module.get_ignore_authors()
+        assert 'dependabot[bot]' in authors
+        assert 'pre-commit-ci[bot]' in authors
+
+    def test_get_ignore_title_prefixes_appends_custom(self, ignore_pr_module, monkeypatch):
+        monkeypatch.setenv('INPUT_IGNORE_TITLE_PREFIXES', 'chore(deps):')
+        importlib.reload(ignore_pr_module)
+        prefixes = ignore_pr_module.get_ignore_title_prefixes()
+        assert 'build(deps):' in prefixes
+        assert 'chore(deps):' in prefixes
+
+    def test_get_ignore_authors_appends_custom(self, ignore_pr_module, monkeypatch):
+        monkeypatch.setenv('INPUT_IGNORE_AUTHORS', 'my-bot[bot]')
+        importlib.reload(ignore_pr_module)
+        authors = ignore_pr_module.get_ignore_authors()
+        assert 'dependabot[bot]' in authors
+        assert 'my-bot[bot]' in authors

--- a/tests/test_sync_pr.py
+++ b/tests/test_sync_pr.py
@@ -135,3 +135,34 @@ def test_sync_remain_prs_handles_bot_accounts(sync_pr_module, mock_sync_issue, m
 
     assert mock_find_jira_issue.call_count == 1
     assert mock_create_jira_issue.call_count == 1
+
+
+def test_sync_remain_prs_skips_ignored_title_prefix(sync_pr_module, mock_sync_issue, mock_github, capsys):
+    """PRs whose title matches a default ignore prefix are skipped without syncing."""
+    mock_jira = MagicMock()
+    mock_create_jira_issue, mock_find_jira_issue = mock_sync_issue
+
+    mock_github.get_pulls.return_value[0].title = 'build(deps): bump actions/download-artifact from 6 to 7'
+
+    with patch.object(sync_pr_module, '_is_collaborator_or_org_member', return_value=None):
+        sync_pr_module.sync_remain_prs(mock_jira)
+
+    assert mock_find_jira_issue.call_count == 0
+    assert mock_create_jira_issue.call_count == 0
+    captured = capsys.readouterr()
+    assert 'Skipping PR' in captured.out or 'ignored' in captured.out.lower()
+
+
+def test_sync_remain_prs_skips_ignored_author(sync_pr_module, mock_sync_issue, mock_github, capsys):
+    """PRs whose author matches a default ignored author are skipped without syncing."""
+    mock_jira = MagicMock()
+    mock_create_jira_issue, mock_find_jira_issue = mock_sync_issue
+
+    mock_github.get_pulls.return_value[0].title = 'Some innocuous title'
+    mock_github.get_pulls.return_value[0].user.login = 'dependabot[bot]'
+
+    with patch.object(sync_pr_module, '_is_collaborator_or_org_member', return_value=None):
+        sync_pr_module.sync_remain_prs(mock_jira)
+
+    assert mock_find_jira_issue.call_count == 0
+    assert mock_create_jira_issue.call_count == 0

--- a/tests/test_sync_to_jira.py
+++ b/tests/test_sync_to_jira.py
@@ -62,6 +62,91 @@ def test_handle_issue_opened_event(mock_environment, sync_to_jira_main, monkeypa
         mock_handle_issue_opened.assert_called_once()
 
 
+def test_pr_with_ignored_title_prefix_is_skipped(mock_environment, monkeypatch, capsys):
+    """PRs whose title matches a default ignore prefix should not trigger handlers."""
+    event_data = {
+        'action': 'opened',
+        'pull_request': {
+            'number': 244,
+            'title': 'build(deps): bump actions/download-artifact from 6 to 7',
+            'body': 'Dependabot update',
+            'user': {'login': 'somebody'},
+            'html_url': 'https://github.com/espressif/esp-idf/pull/244',
+            'state': 'open',
+            'labels': [],
+        },
+    }
+    mock_environment.write_text(json.dumps(event_data))
+    monkeypatch.setenv('GITHUB_EVENT_NAME', 'pull_request')
+    monkeypatch.setenv('JIRA_PROJECT', 'TEST_PROJECT')
+
+    mock_repo = MagicMock()
+    mock_repo.has_in_collaborators.return_value = False
+    mock_repo.owner.type = 'Organization'
+    mock_repo.owner.login = 'espressif'
+
+    mock_org = MagicMock()
+    mock_org.has_in_members.return_value = False
+
+    mock_github_instance = MagicMock()
+    mock_github_instance.get_repo.return_value = mock_repo
+    mock_github_instance.get_organization.return_value = mock_org
+
+    with (
+        patch('sync_jira_actions.sync_to_jira.Github', return_value=mock_github_instance),
+        patch('sync_jira_actions.sync_to_jira._JIRA'),
+        patch('sync_jira_actions.sync_to_jira.handle_issue_opened') as mock_handle_issue_opened,
+    ):
+        from sync_jira_actions.sync_to_jira import main
+
+        main()
+        mock_handle_issue_opened.assert_not_called()
+
+    captured = capsys.readouterr()
+    assert 'Skipping PR' in captured.out
+
+
+def test_pr_with_ignored_author_is_skipped(mock_environment, monkeypatch):
+    """PRs authored by a default ignored author should not trigger handlers."""
+    event_data = {
+        'action': 'opened',
+        'pull_request': {
+            'number': 99,
+            'title': 'Some innocent title',
+            'body': 'Dependabot update',
+            'user': {'login': 'dependabot[bot]'},
+            'html_url': 'https://github.com/espressif/esp-idf/pull/99',
+            'state': 'open',
+            'labels': [],
+        },
+    }
+    mock_environment.write_text(json.dumps(event_data))
+    monkeypatch.setenv('GITHUB_EVENT_NAME', 'pull_request')
+    monkeypatch.setenv('JIRA_PROJECT', 'TEST_PROJECT')
+
+    mock_repo = MagicMock()
+    mock_repo.has_in_collaborators.return_value = False
+    mock_repo.owner.type = 'Organization'
+    mock_repo.owner.login = 'espressif'
+
+    mock_org = MagicMock()
+    mock_org.has_in_members.return_value = False
+
+    mock_github_instance = MagicMock()
+    mock_github_instance.get_repo.return_value = mock_repo
+    mock_github_instance.get_organization.return_value = mock_org
+
+    with (
+        patch('sync_jira_actions.sync_to_jira.Github', return_value=mock_github_instance),
+        patch('sync_jira_actions.sync_to_jira._JIRA'),
+        patch('sync_jira_actions.sync_to_jira.handle_issue_opened') as mock_handle_issue_opened,
+    ):
+        from sync_jira_actions.sync_to_jira import main
+
+        main()
+        mock_handle_issue_opened.assert_not_called()
+
+
 def test_pr_opened_by_bot_account_does_not_crash(mock_environment, monkeypatch):
     """Test that PRs opened by bot accounts (e.g. copilot[bot]) don't crash the sync"""
     from github import GithubException


### PR DESCRIPTION
## Description

Bot-generated PRs can feel noisy. This feature makes it possible to ignore pull requests by author and title prefix, using default patterns for Dependabot and pre-commit.ci.

## Implemented changes

- added new module sync_jira_actions/ignore_pr.py
- introduced default ignored title prefixes:
    - build(deps):
    - build(deps-dev):
    - [pre-commit.ci]
- introduced default ignored authors:
    - dependabot[bot]
    - pre-commit-ci[bot]
- added helper functions for parsing configured prefixes/authors
- added should_ignore_pr(title, author_login) returning (bool, reason)
- added action inputs:
    - ignore-title-prefixes
    - ignore-authors
- documented usage in README

## Related

SRV-117: Ignore PRs with Certain Patterns

## Testing

Added unit tests for ignoring logic.